### PR TITLE
Add Character Counter feature and utility function

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@mui/material": "^7.3.2",
     "@textea/json-viewer": "^3.1.1",
     "diff-match-patch": "^1.0.5",
     "framer-motion": "^6.5.1",

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -26,6 +26,7 @@ const JsonViewer = lazy(() => import("./../pages/Text Tools/JsonViewer"));
 const JsonComparator = lazy(() => import("./../pages/Text Tools/JsonComparator"));
 const TextComparator = lazy(() => import("./../pages/Text Tools/TextComparator"));
 const Regex = lazy(() => import("./../pages/Text Tools/Regex"));
+const CharacterCounter = lazy(() => import("./../pages/Text Tools/CharacterCounter"));
 
 const DateTimeConverter = lazy(() => import("./../pages/DateTime Tools/DateTimeConverter"));
 
@@ -62,12 +63,13 @@ export const LinkItems: Array<LinkItemProps> = [
   {
     name: 'Text Tools', icon: FiFileText, key: "textTools",
     child: [
+      {name: "Character Counter", link: "character-counter", element: <CharacterCounter /> },
       { name: "Text Comparator", link: "text-comparator", element: <TextComparator /> },
       { name: "Regex Templates", link: "regex", element: <Regex /> },
       { name: "Beautifier/Minifier", link: "beautifier-minifier", element: <Beautifier /> },
       { name: "JSON Viewer", link: "json-viewer", element: <JsonViewer /> },
       { name: "JSON Comparator", link: "json-comparator", element: <JsonComparator /> },
-      { name: "YAML Validator", link: "yaml-validator", element: <YamlValidator /> }
+      { name: "YAML Validator", link: "yaml-validator", element: <YamlValidator /> },
     ]
   },
   {

--- a/src/pages/Text Tools/CharacterCounter.tsx
+++ b/src/pages/Text Tools/CharacterCounter.tsx
@@ -1,0 +1,48 @@
+import { Badge, Flex, FormControl, Heading, Stack, Textarea, useColorModeValue } from "@chakra-ui/react"
+import { useState } from "react";
+const CharacterCounter = () => {
+  const [text, setText] = useState("");
+  const [count, setCount] = useState(0);
+  return (
+    <Flex
+          minH={'100vh'}
+          align={'center'}
+          justify={'center'}>
+            <Stack
+              spacing={4}
+              w={'full'}
+              maxW={'md'}
+              bg={useColorModeValue('white', 'gray.700')}
+              rounded={'lg'}
+              boxShadow={'lg'}
+              borderWidth={1}
+              borderColor={useColorModeValue('gray.200', 'gray.700')}
+              p={6}>
+              <Heading lineHeight={1.1} fontSize={{ base: '2xl', md: '3xl' }}>
+                Character Counter
+              </Heading>
+               
+                <Textarea
+                  placeholder="Input Text"
+                  _placeholder={{ color: 'gray.500' }}
+                  outlineColor={useColorModeValue('gray.300', 'gray.600')}
+                  value={text}
+                  onChange={
+                    (e) => {
+                      setText(e.target.value);
+                      setCount(e.target.value.length);
+                    }
+                  }
+                  fontFamily="monospace"
+                />
+                <Badge>
+                  Character Count: {count}
+                </Badge>
+              </Stack>
+              
+        </Flex>
+
+  )
+}
+
+export default CharacterCounter;

--- a/src/utils/text-utils.js
+++ b/src/utils/text-utils.js
@@ -1,0 +1,5 @@
+const characterCounter=(text) => {
+  return text.length;
+};
+
+module.exports = { characterCounter };


### PR DESCRIPTION
This pull request adds a new "Character Counter" feature to the Text Tools section of the app. The main changes include adding the new page, updating navigation, and introducing a supporting utility function. Additionally, a new dependency for Material UI is included.

**Feature Addition: Character Counter**
* Added a new `CharacterCounter` page component in `src/pages/Text Tools/CharacterCounter.tsx`, allowing users to input text and view the character count in real time.
* Registered the new page in the app's router and navigation by lazy loading `CharacterCounter` and adding it to the `LinkItems` array under Text Tools. [[1]](diffhunk://#diff-a9c19fbf2163e551c732994a4286cfa0ea6bba41eafd7e9a18252604bce0a3c9R29) [[2]](diffhunk://#diff-a9c19fbf2163e551c732994a4286cfa0ea6bba41eafd7e9a18252604bce0a3c9R66-R72)

**Utilities**
* Added a new `characterCounter` utility function in `src/utils/text-utils.js` to calculate the length of a given text.

**Dependencies**
* Added `@mui/material` as a new dependency in `package.json` for potential future UI enhancements.